### PR TITLE
Specific project/auto

### DIFF
--- a/ease_customized_calibration.py
+++ b/ease_customized_calibration.py
@@ -39,13 +39,47 @@ shrink_sound = sound.Sound(SHRINK_SOUND_PATH)
 # setup the attention grabber during adjusting the participant's position
 grabber = visual.MovieStim3(win, "infant/seal-clip.mp4")
 
+def main_calibration(
+    self,
+    _focus_time=0.5,
+    collect_key='space',
+    exit_key='return'
+    ):
+    # run automated procedure if it hasn't already been run
+    if not hasattr(self, 'automated_calib_done'):
+        automated_calibration(
+            self,
+            _focus_time,
+            collect_key,
+            exit_key
+        )
+        # add attribute to 'self', ie the TobiiInfantController
+        # instance, to indicate that automated calibration
+        # has been run
+        # (any additional calibrations are to be done 'manually')
+        self.automated_calib_done = True
+    else:
+        manual_calibration(
+            self,
+            _focus_time,
+            collect_key,
+            exit_key
+        )
 
 # create a customized calibration procedure with sound
 # code snippets copied from _update_calibration_infant()
-def customized_update_calibration(self,
-                                  _focus_time=0.5,
-                                  collect_key='space',
-                                  exit_key='return'):
+def manual_calibration(
+    self,
+    _focus_time=0.5,
+    collect_key='space',
+    exit_key='return'
+    ):
+    """
+    A customized manual (see automated version below)
+    calibration procedure which uses shrink/grow sounds.
+    Partly uses code copied from the psychopy_tobii_infant 
+    package's demos.
+    """
     # boolean indicating if calibration data are to be collected
     # when target is shrunk to close to minimum size
     collect_when_shrunk = False
@@ -95,6 +129,96 @@ def customized_update_calibration(self,
             self.targets[current_point_index].draw()
             
             # handle playing sounds if target started growing/shrinking
+            if  vbcx is not None:
+                target_is_growing = previous_frame_width < newsize[0]
+                if target_is_growing and allow_grow_sound:
+                    grow_sound.play()
+                    shrink_sound.stop()
+                    allow_grow_sound = False
+                    allow_shrink_sound = True
+                elif not target_is_growing and allow_shrink_sound:
+                    shrink_sound.play()
+                    grow_sound.stop()
+                    allow_shrink_sound = False
+                    allow_grow_sound = True
+            previous_frame_width = newsize[0]
+        
+        # get current target width 
+        target_curr_width = self.targets[current_point_index].size[0]
+        if collect_when_shrunk:
+            # check if the current target width is less than twice
+            # as large as the minimum possible width
+            if target_curr_width < (2 * target_min_width):
+                # allow the participant to focus
+                core.wait(_focus_time)
+                # collect calibration data
+                self._collect_calibration_data(
+                    self.original_calibration_points[current_point_index]
+                )
+                # reset calibration point index and calibration-related
+                # boolean
+                current_point_index = -1
+                collect_when_shrunk = False
+        self.win.flip()
+
+def automated_calibration(
+    self,
+    _focus_time=0.5,
+    collect_key='space',
+    exit_key='return'):
+    """
+    This is an automated version of the above 'manual'
+    calibration function. It is to be run the first time through -
+    any following recalibrations are handled manually, ie
+    by the experimenter.
+    """
+    # boolean indicating if calibration data are to be collected
+    # when target is shrunk to close to minimum size
+    collect_when_shrunk = False
+    # booleans indicating if shrink/grow sounds are allowed to be
+    # played (these are for avoiding sounds being repeatedly started
+    # in very quick succession)
+    allow_grow_sound = True
+    allow_shrink_sound = True
+    # boolean indicating if the target is currently growing
+    target_is_growing = False
+    # variable for holding previous frame's target width
+    previous_frame_width = None
+    # minimum possible target width
+    target_min_width = self.target_original_size[0] * self.calibration_target_min
+    # start calibration
+    event.clearEvents()
+    current_point_index = -1
+    in_calibration = True
+    clock = core.Clock()
+    # time at which the currently active target started being shown
+    # (the default value assigned here will be overwritten, see below)
+    target_start_time = clock.getTime()
+    # form a list of the target position numbers
+    pos_nums = self.numkey_dict.keys()
+    while in_calibration:
+        # if calibration hasn't already been set to trigger,
+        # and there are still points left to calibrate with
+        if not collect_when_shrunk and pos_nums:
+            # get the number of the position for which data will be fetched this time
+            pos_num = pos_nums.pop()
+            current_point_index = self.numkey_dict[key]
+            target_start_time = clock.getTime()
+            # trigger calibration data collection once target has
+            # shrunk enough
+            collect_when_shrunk = True
+        
+        # draw calibration target
+        if current_point_index in self.retry_points:
+            self.targets[current_point_index].setPos(
+                self.original_calibration_points[current_point_index])
+            t = (clock.getTime() - target_start_time) * self.shrink_speed
+            newsize = [(np.cos(t)**2 + self.calibration_target_min) * e
+                       for e in self.target_original_size]
+            self.targets[current_point_index].setSize(newsize)
+            self.targets[current_point_index].draw()
+            
+            # handle playing sounds if target started growing/shrinking
             if previous_frame_width is not None:
                 target_is_growing = previous_frame_width < newsize[0]
                 if target_is_growing and allow_grow_sound:
@@ -126,15 +250,21 @@ def customized_update_calibration(self,
                 current_point_index = -1
                 collect_when_shrunk = False
         self.win.flip()
-        
-        
+        # if calibration for current point is done, and there
+        # are no points left to calibrate for, end calibration
+        if not collect_when_shrunk and not pos_nums:
+            in_calibration = False
+
+
 
 
 # initialize TobiiInfantController to communicate with the eyetracker
 controller = TobiiInfantController(win)
 # use the customized calibration
-controller.update_calibration = types.MethodType(customized_update_calibration,
-                                                 controller)
+controller.update_calibration = types.MethodType(
+    main_calibration,
+    controller
+)
 
 # setup the attention grabber during adjusting the participant's position
 grabber.setAutoDraw(True)

--- a/ease_customized_calibration.py
+++ b/ease_customized_calibration.py
@@ -32,7 +32,8 @@ win = visual.Window(size=(1920, 1080),
                     units='pix',
                     fullscr=True,
                     allowGUI=False,
-                    screen=0)
+                    color=[1, 1, 1],
+                    screen=1)
 
 # prepare the audio stimuli used in calibration
 grow_sound = sound.Sound(GROW_SOUND_PATH)
@@ -318,7 +319,7 @@ while waitkey:
     # The value is numpy.nan if Tobii failed to detect gaze position.
     if np.nan not in currentGazePosition:
         marker.setPos(currentGazePosition)
-        marker.setLineColor('white')
+        marker.setLineColor('black')
     else:
         marker.setLineColor('red')
     keys = event.getKeys()

--- a/ease_customized_calibration.py
+++ b/ease_customized_calibration.py
@@ -22,8 +22,16 @@ CALISTIMS = [
     'infant/{}'.format(x) for x in os.listdir(os.path.join(DIR, 'infant'))
     if x.endswith('.png') and not x.startswith('.')
 ]
+# keyboard key that is to be used, during calibration, for temporarily switching 
+# back to the attention grabber movie, if the child seems to lose all interest
+# in the screen. pick **a letter** here, since the code below ensures that
+# both upper-and lowercase versions of the letter (eg 'a' or 'A') are checked
+# for, to avoid issues with caps lock
+ATTENTION_GRAB_KEY = 'a'
+# relative paths to grow/shrink sound files
 GROW_SOUND_PATH = 'infant/grow.wav'
 SHRINK_SOUND_PATH = 'infant/shrink.wav'
+
 
 ###############################################################################
 # Demo
@@ -48,6 +56,9 @@ def main_calibration(
     collect_key='space',
     exit_key='return'
     ):
+    # set boolean property that indicates if the experimenter wants to
+    # temporarily show the attention grabber movie at the moment
+    self.show_att_grabber = False
     # run automated procedure if it hasn't already been run
     if not hasattr(self, 'automated_calib_done'):
         automated_calibration(
@@ -120,6 +131,21 @@ def manual_calibration(
                 # exit calibration when return is presssed
                 in_calibration = False
                 break
+            elif key.lower() == ATTENTION_GRAB_KEY:
+                # toggle attention grabber movie on/off
+                self.show_att_grabber = not self.show_att_grabber
+                # pause (if it was previously playing) or start (
+                # if it wasn't previously playing) attention grabber
+                # movie
+                grabber.play() if self.show_att_grabber else grabber.pause()
+        
+        # if the experimenter wants to temporarily play part of the
+        # attention grabber movie, keep playing it and don't do anything
+        # else this frame
+        if self.show_att_grabber:
+            grabber.draw()
+            win.flip()
+            continue
 
         # draw calibration target
         if current_point_index in self.retry_points:
@@ -279,7 +305,8 @@ controller.show_status()
 
 # stop the attention grabber
 grabber.setAutoDraw(False)
-grabber.stop()
+# pause movie, so that it can then be switched back to during calibration
+grabber.pause()
 
 # How to use:
 # The first 'calibration run' is automated, just let it run.
@@ -298,7 +325,7 @@ grabber.stop()
 #   is delayed, if necessary, until the target has shrunk down)
 # - Press return (Enter) to finish the recalibration and see the 
 #   updated results.
-success = controller.run_calibration(CALIPOINTS, CALISTIMS)
+success = controller.run_calibration(CALIPOINTS, CALISTIMS, result_msg_color="black")
 if not success:
     core.quit()
 

--- a/psychopy_tobii_infant/__init__.py
+++ b/psychopy_tobii_infant/__init__.py
@@ -581,7 +581,8 @@ class TobiiController:
         self.datafile.close()
 
     def run_calibration(self, calibration_points,
-                        focus_time=0.5, decision_key="space"):
+                        focus_time=0.5, decision_key="space",
+                        result_msg_color="white"):
         """Run calibration
 
         Args:
@@ -636,7 +637,7 @@ class TobiiController:
         result_msg = visual.TextStim(
             self.win,
             pos=(0, -self.win.size[1] / 4),
-            color="white",
+            color=result_msg_color,
             units="pix",
             alignText="left",
             autoLog=False,
@@ -723,7 +724,8 @@ class TobiiController:
                        focus_time=0.5,
                        decision_key="space",
                        show_results=False,
-                       save_to_file=True):
+                       save_to_file=True,
+                       result_msg_color="white"):
         """Run validation.
 
         tobii_research_addons is required for running validation.
@@ -817,7 +819,7 @@ class TobiiController:
         if show_results:
             result_msg = visual.TextStim(self.win,
                                          pos=(0, -self.win.size[1] / 4),
-                                         color="white",
+                                         color=result_msg_color,
                                          units="pix",
                                          alignText="left",
                                          wrapWidth=self.win.size[0] * 0.6,
@@ -1166,7 +1168,8 @@ class TobiiInfantController(TobiiController):
                         infant_stims,
                         audio=None,
                         focus_time=0.5,
-                        decision_key="space"):
+                        decision_key="space",
+                        result_msg_color="white"):
         """Run calibration.
 
             How to use:
@@ -1231,7 +1234,7 @@ class TobiiInfantController(TobiiController):
         result_msg = visual.TextStim(
             self.win,
             pos=(0, -self.win.size[1] / 4),
-            color="white",
+            color=result_msg_color,
             units="pix",
             autoLog=False,
         )


### PR DESCRIPTION
Automate running first calibration attempt, while subsequent calibration attempts are done 'manually' through experimenter control. (the code works but is _not_ DRY and should be rewritten if there is time) Add argument (in package's source code) for specifying post-calibration result text color, and change to using black background/white text in calibration script.